### PR TITLE
Add opaque type field inference and mock-constructor support

### DIFF
--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -1387,7 +1387,7 @@ interpretert::input_varst& interpretert::load_counter_example_inputs(
       {
         inputs[id]=it->full_lhs_value;
       }
-      std::cout << it->pc->type << std::endl;
+      std::cout << it->pc->type << " " << symbol_expr.get_identifier() << std::endl;
       irep_idt f_id;
       if(is_opaque_function(it->pc,f_id)!=0)
       {

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -1387,7 +1387,8 @@ interpretert::input_varst& interpretert::load_counter_example_inputs(
       {
         inputs[id]=it->full_lhs_value;
       }
-      std::cout << it->pc->type << " " << symbol_expr.get_identifier() << std::endl;
+      std::cout << it->pc->type << " " << symbol_expr.get_identifier() << " " << from_expr(ns, id, inputs[id]) << std::endl;
+      
       irep_idt f_id;
       if(is_opaque_function(it->pc,f_id)!=0)
       {

--- a/src/java_bytecode/java_bytecode_convert.cpp
+++ b/src/java_bytecode/java_bytecode_convert.cpp
@@ -838,8 +838,13 @@ codet java_bytecode_convertt::convert_instructions(
       {
         if(parameters.empty() || !parameters[0].get_this())
         {
-          const empty_typet empty;
-          pointer_typet object_ref_type(empty);
+	  typet thistype = empty_typet();
+	  if(statement == "invokespecial") {
+	    // Constructor -- infer the "this" type must match the type implied by the name.
+	    irep_idt classname = arg0.get(ID_C_class);
+	    thistype = symbol_typet(classname);
+	  }
+          pointer_typet object_ref_type(thistype);
           code_typet::parametert this_p(object_ref_type);
           this_p.set_this();
           this_p.set_base_name("this");

--- a/src/java_bytecode/java_bytecode_convert.cpp
+++ b/src/java_bytecode/java_bytecode_convert.cpp
@@ -843,6 +843,7 @@ codet java_bytecode_convertt::convert_instructions(
 	    // Constructor -- infer the "this" type must match the type implied by the name.
 	    irep_idt classname = arg0.get(ID_C_class);
 	    thistype = symbol_typet(classname);
+	    code_type.set(ID_constructor, true);
 	  }
           pointer_typet object_ref_type(thistype);
           code_typet::parametert this_p(object_ref_type);

--- a/src/java_bytecode/java_bytecode_language.cpp
+++ b/src/java_bytecode/java_bytecode_language.cpp
@@ -203,6 +203,8 @@ bool java_bytecode_languaget::final(symbol_tablet &symbol_table)
   */
   java_internal_additions(symbol_table);
 
+  java_insert_nondet_opaque_fields(symbol_table);
+
   if(java_entry_point(symbol_table, main_class, get_message_handler()))
     return true;
   

--- a/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -208,26 +208,38 @@ Function: java_bytecode_typecheckt::typecheck_expr_symbol
 
 void java_bytecode_typecheckt::typecheck_expr_member(member_exprt &expr)
 {
-  // The member might be in a parent class, which we resolve here.
+  // The member might be in a parent class or an opaque class, which we resolve here.
   const irep_idt component_name=expr.get_component_name();
   
   while(1)
   {
-    if(ns.follow(expr.struct_op().type()).id()!=ID_struct)
+
+    typet &base_type = const_cast<typet&>(ns.follow(expr.struct_op().type()));
+    
+    if(base_type.id()!=ID_struct)
       break; // give up
   
-    const struct_typet &struct_type=
-      to_struct_type(ns.follow(expr.struct_op().type()));
+    struct_typet &struct_type=
+      to_struct_type(base_type);
 
     if(struct_type.has_component(component_name))
       return; // done
 
     // look at parent
-    const struct_typet::componentst &components=
+    struct_typet::componentst &components=
       struct_type.components();
     
+    if(struct_type.get_bool(ID_incomplete_class)) {
+      // Member doesn't exist. In this case struct_type should be an opaque
+      // stub, and we'll add the member to it.
+      components.push_back(struct_typet::componentt(component_name, expr.type()));
+      components.back().set_base_name(component_name);
+      components.back().set_pretty_name(component_name);
+      return;
+    }
+
     if(components.empty())
-      break; // give up
+      break;
 
     const struct_typet::componentt &c=components.front();
     

--- a/src/java_bytecode/java_entry_point.cpp
+++ b/src/java_bytecode/java_entry_point.cpp
@@ -797,7 +797,7 @@ void insert_nondet_opaque_fields(codet &code, symbol_tablet& symbol_table, code_
       // an override we don't know about)
 
       assert(callee_type.has_this() && "Dynamic dispatch but not instance method?");
-      if(is_opaque_type(callee_type.parameters()[0].type(), symbol_table)
+      if(is_opaque_type(code_function_call.arguments()[0].type(), symbol_table)
 	 && is_opaque_type(callee_type.return_type(), symbol_table)) {
 	
 	insert_nondet_opaque_fields_at(callee_type.return_type(),

--- a/src/java_bytecode/java_entry_point.h
+++ b/src/java_bytecode/java_entry_point.h
@@ -16,4 +16,6 @@ bool java_entry_point(
   const irep_idt &main_class,
   class message_handlert &message_handler);
 
+void java_insert_nondet_opaque_fields(symbol_tablet &symbol_table);
+
 #endif

--- a/src/test_gen/java_test_source_factory.cpp
+++ b/src/test_gen/java_test_source_factory.cpp
@@ -272,13 +272,14 @@ std::string &add_func_call(std::string &result, const symbol_tablet &st,
   indent(result, 2u) += symbol_to_function_name(s);
   result+='(';
   const std::set<irep_idt> params(get_parameters(s));
+  unsigned nparams = 0;
   for (const irep_idt &param : params)
   {
+    if(nparams++ != 0)
+      result+=", ";
     add_symbol(result, st.lookup(param));
-    result+=',';
   }
-  *result.rbegin()=')';
-  result+=";\n";
+  result+=");\n";
   indent(result)+="}\n";
   return result+="}\n";
 }
@@ -390,8 +391,8 @@ std::string generate_java_test_case_from_inputs(const symbol_tablet &st,
   ref_factory.add_func_call_parameters(post_mock_setup_result, st, func_id, inputs);
   // Finalise happens here because add_func_call_parameters et al
   // may have generated mock objects.
-  ref_factory.mockenv_builder.finalise_instance_calls();
-  result += "\n" + ref_factory.mockenv_builder.get_mock_prelude() + "\n\n" + post_mock_setup_result;
+  std::string mock_final = ref_factory.mockenv_builder.finalise_instance_calls();
+  result += "\n" + ref_factory.mockenv_builder.get_mock_prelude() + "\n\n" + post_mock_setup_result + "\n\n" + mock_final;
   return add_func_call(result, st, func_id);
 }
 

--- a/src/test_gen/mock_environment_builder.cpp
+++ b/src/test_gen/mock_environment_builder.cpp
@@ -138,11 +138,14 @@ static void generate_arg_matchers(std::ostringstream& printto, const std::string
 
 }
 
-void mock_environment_builder::finalise_instance_calls() {
+std::string mock_environment_builder::finalise_instance_calls() {
 
   // We've created a number of mock objects of various types. Hook them up to their type-global
   // list of function return values.
 
+  std::ostringstream result;
+  result << prelude_newline;
+  
   for(auto iter : instance_method_answers) {
 
     const auto& mocknames = mock_instance_names[iter.first.classname];
@@ -152,13 +155,14 @@ void mock_environment_builder::finalise_instance_calls() {
 
     for(const auto& name : mocknames) {
 
-      generate_arg_matchers(mock_prelude, name, iter.first.methodname, iter.first.argtypes);
-
-      mock_prelude << ".thenAnswer(" << iter.second.answer_object << ");" << prelude_newline;
+      generate_arg_matchers(result, name, iter.first.methodname, iter.first.argtypes);
+      result << ".thenAnswer(" << iter.second.answer_object << ");" << prelude_newline;
 
     }
 
   }
+
+  return result.str();
 
 }
 

--- a/src/test_gen/mock_environment_builder.cpp
+++ b/src/test_gen/mock_environment_builder.cpp
@@ -23,24 +23,7 @@ void mock_environment_builder::register_mock_instance(const std::string& tyname,
 // Create a fresh mock instance.
 std::string mock_environment_builder::instantiate_mock(const std::string& tyname, bool is_constructor) {
 
-  /*
-  if(is_constructor) {
-    
-
-
-
-  }
-  */
-
   return "org.mockito.Mockito.mock(" + tyname + ".class);";
-  /*
-  if(is_constructor) {
-
-    // Intercept the next constructor call and return this:
-
-
-  }
-  */
 
 }
 

--- a/src/test_gen/mock_environment_builder.h
+++ b/src/test_gen/mock_environment_builder.h
@@ -84,7 +84,7 @@ class mock_environment_builder {
   void instance_call(const std::string& targetclass, const std::string& methodname, const std::vector<std::string>& argtypes, const std::string& rettype, const std::string& retval);
 
   // Write instance method interception code that can only be generated once all required intercepts are known.
-  void finalise_instance_calls();
+  std::string finalise_instance_calls();
   
   // Intercept the next static call to targetclass.methodname(argtypes...) and return retval.
   void static_call(const std::string& targetclass, const std::string& methodname, const std::vector<std::string>& argtypes, const std::string& retval);

--- a/src/test_gen/mock_environment_builder.h
+++ b/src/test_gen/mock_environment_builder.h
@@ -56,16 +56,15 @@ instance_method_answer(const std::string& ao, const std::string& al) :
 
 class mock_environment_builder {
 
-  // Count how many fresh instances we've produced of each typename, to generate fresh names.
-  std::unordered_map<std::string, unsigned long> name_counter;
+  // Track mock instance names, so we can connect up the answer-list objects
+  // during finalisation.
+  std::unordered_map<std::string, std::vector<std::string> > mock_instance_names;
 
   // Track class instance methods that have an answer object set up.
   std::unordered_map<method_signature, instance_method_answer> instance_method_answers;
 
   // Build up a set of classes that need PowerMock setup (those whose constructors and/or static methods we need to intercept)
-  std::set<std::string> powermock_classes;
-
-  // Accumulate mock object setup statements that will precede the test case entry point
+  std::set<std::string> powermock_classes;  // Accumulate mock object setup statements that will precede the test case entry point
   std::ostringstream mock_prelude;
 
   // Newline character plus indenting for the prelude:
@@ -75,9 +74,12 @@ class mock_environment_builder {
 
   mock_environment_builder(unsigned int ip);
   
-  // Generate mock setup code for a fresh instance of 'tyname'; return a unique local name for it.
-  std::string get_fresh_instance(const std::string& tyname, bool is_constructor);
+  // Add a mock to mock_instance_names
+  void register_mock_instance(const std::string& tyname, const std::string& instancename);
 
+  // Intercept the next constructor call to tyname and return a fresh mock instance.
+  std::string instantiate_mock(const std::string& tyname, bool is_constructor);
+  
   // Intercept the next instance call to targetobj.methodname(paramtype0, paramtype1, ...) and return retval.
   void instance_call(const std::string& targetclass, const std::string& methodname, const std::vector<std::string>& argtypes, const std::string& rettype, const std::string& retval);
 
@@ -87,9 +89,16 @@ class mock_environment_builder {
   // Intercept the next static call to targetclass.methodname(argtypes...) and return retval.
   void static_call(const std::string& targetclass, const std::string& methodname, const std::vector<std::string>& argtypes, const std::string& retval);
 
+  // Return retval the next time a targetclass is constructed.
+  void constructor_call(const std::string& targetclass, const std::vector<std::string>& argtypes, const std::string& retval);
+  
   // Return annotations needed for the main class to run under JUnit:
   std::string get_class_annotations();
 
+  void add_to_prelude(const std::string& toadd) {
+    mock_prelude << toadd << prelude_newline;
+  }
+  
   // Return the mock setup code that should directly precede the test entry point.
   std::string get_mock_prelude() { return mock_prelude.str(); }
   


### PR DESCRIPTION
This adds opaque type field inference (filling out the field structure of an opaque type by observing attempts to access its fields) and support for returning mock objects from constructor calls during a test.

For example, the following now passes:

```java
class test2 {

  public static void test() {

    opaque2 o1 = new opaque2();
    opaque2 o2 = new opaque2();

    if(o1.x != 0 && o2.x != 0 && o1.y != 0 && o2.y != 0)
      assert(o1.x + o1.y == o2.x + o2.y);

  }

}

class opaque2 {

  public int x;
  public int y;

}
```

When `opaque2.class` is unavailable, we generate this test:

```java
@org.junit.runner.RunWith(org.powermock.modules.junit4.PowerMockRunner.class)
@org.powermock.core.classloader.annotations.PrepareForTest( { opaque2.class } )
public class test2_testXYTest {
  @org.junit.Test public void testtest2_testXY() {


    opaque2 mock_instance_1 = (opaque2) org.mockito.Mockito.mock(opaque2.class);;
    Reflector.setInstanceField(mock_instance_1,"x",-2147483648);
    Reflector.setInstanceField(mock_instance_1,"y",-2147483648);
    org.powermock.api.mockito.PowerMockito.whenNew(opaque2.class).withAnyArguments().thenReturn(mock_instance_1);
    opaque2 mock_instance_2 = (opaque2) org.mockito.Mockito.mock(opaque2.class);;
    Reflector.setInstanceField(mock_instance_2,"x",-2147483647);
    Reflector.setInstanceField(mock_instance_2,"y",-2147483648);
    org.powermock.api.mockito.PowerMockito.whenNew(opaque2.class).withAnyArguments().thenReturn(mock_instance_2);
    final java.util.ArrayList<Boolean> java_lang_Class_desiredAssertionStatus_answer_list = new java.util.ArrayList<Boolean>();
    final IterAnswer java_lang_Class_desiredAssertionStatus_answer_object = new IterAnswer<Boolean>(java_lang_Class_desiredAssertionStatus_answer_list);
    java_lang_Class_desiredAssertionStatus_answer_list.add(true);
    

    test2.test);
  }
}
```

Detailed changes:

- Add to opaque class types during Java typechecking phase when a field reference cannot be resolved (only classes with `ID_incomplete_class`, including base types, are included.
- Insert nondet field assignments after any opaque method that constructs or returns an opaque type.
- Improve annotation and type inference for constructor methods of opaque types.
- Add support for generating mock objects that are returned by runtime constructor calls.

Current caveats:

- Returned (rather than constructed) opaque objects not supported yet.
- Opaque superclasses of elaborated (available) classes are supported by field inference and nondet field generation, but not by testcase generation yet.
- Trees of mock objects, or of elaborated and opaque objects, not tested.